### PR TITLE
INTERLOK-2877

### DIFF
--- a/consumers/jms-queue-consumer.xml
+++ b/consumers/jms-queue-consumer.xml
@@ -13,9 +13,9 @@
          wizard-jms-order="0" wizard-jms-desc="Configure the JMS Consumer"
 >
   <destination class="configured-consume-destination">
-    <destination wizard-key="JMSTopic"
-                 wizard-label="JMS Topic"
-                 wizard-desc="The JMS Topic"
+    <destination wizard-key="JMSQueue"
+                 wizard-label="JMS Queue"
+                 wizard-desc="The JMS Queue"
                  wizard-step="jms">
     </destination>
   </destination>


### PR DESCRIPTION
Template refers to JMS Topic when creating a JMS Queue Consumer.

Fix does not address secondary issue: "[Destination] Field begins with extraneous white-space."